### PR TITLE
Renamed file, see desc

### DIFF
--- a/BruteForceWolframWords.m
+++ b/BruteForceWolframWords.m
@@ -113,4 +113,3 @@ VCBruteForceKey3[cipher_, showReject_:False, print_:False] := Module[
 
 cipher = VigenereCipher["St. Olaf College", "YAH"]
 VCBruteForceKey3[cipher]
-


### PR DESCRIPTION
Current brute force algorithm leverages Mathematica's dictionary to check for words, which is a bit cheating. Rename to allow for work on a 'proper' brute force attack using frequency tables/fitness.